### PR TITLE
Toreleon fix ci errors (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,23 +56,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install poetry
         
-    - name: Bump version
-      run: |
-        # Get the current version
-        current_version=$(poetry version -s)
-        echo "Current version: $current_version"
-        
-        # Bump patch version
-        poetry version patch
-        new_version=$(poetry version -s)
-        echo "Bumped to version: $new_version"
-        
-        # Commit the version change
-        git config --global user.name 'GitHub Actions'
-        git config --global user.email 'actions@github.com'
-        git commit -am "Bump version to $new_version [skip ci]"
-        git push
-        
     - name: Build and publish
       env:
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,6 +36,7 @@ jobs:
         python - << 'EOF'
         import tomlkit
         import re
+        import os
         
         # Read current version from pyproject.toml
         with open('pyproject.toml', 'r') as f:
@@ -56,9 +57,20 @@ jobs:
         pyproject['project']['version'] = new_version
         with open('pyproject.toml', 'w') as f:
             f.write(tomlkit.dumps(pyproject))
+            
+        # Save the new version to an environment variable for later steps
+        with open(os.environ['GITHUB_ENV'], 'a') as f:
+            f.write(f"NEW_VERSION={new_version}\n")
         EOF
         
         # Commit and push changes
         git add pyproject.toml
-        git commit -m "Bump version for new release"
+        git commit -m "Bump version to ${NEW_VERSION} [skip ci]"
         git push
+    
+    - name: Create and push tag
+      run: |
+        # Create a new tag with the bumped version
+        git tag -a "v${NEW_VERSION}" -m "Release version ${NEW_VERSION}"
+        # Push the tag to the remote repository
+        git push origin "v${NEW_VERSION}"

--- a/README.md
+++ b/README.md
@@ -315,9 +315,12 @@ This project uses GitHub Actions for continuous integration and deployment:
 
 1. **Automated Testing**: Tests are run on Python 3.10, 3.11, and 3.12 for every push to main and release branches and for pull requests.
 
-2. **Automatic Version Bumping**: When code is pushed to the `release` branch, the patch version is automatically incremented.
+2. **Automatic Version Bumping and Tagging**: When code is pushed to the `release` branch:
+   - The patch version is automatically incremented in `pyproject.toml`
+   - A new Git tag (e.g., `v0.1.2`) is created for the release
+   - Changes are committed back to the repository
 
-3. **PyPI Publishing**: When code is merged to the `release` branch and tests pass, the package is automatically built and published to PyPI.
+3. **PyPI Publishing**: When code is pushed to the `release` branch and tests pass, the package is automatically built and published to PyPI.
 
 #### Setting Up PyPI Deployment
 


### PR DESCRIPTION
* Add CI/CD workflows for testing, version bumping, and PyPI publishing; enhance README with development and CI/CD details; implement comprehensive tests for MCPHub and MCPServers functionality.

* Enhance CI workflow by installing all extras with Poetry

* Refactor CI workflow to include version bumping and streamline package publishing using Poetry

* Update README to clarify MCPHub installation options with framework-specific dependencies

* Restrict pull request triggers to the release branch only

* Update CI workflow to enable fail-fast strategy and restrict Python versions to 3.12 only

* Refactor CI workflows to remove version bumping from CI and add tagging functionality; update README for clarity on automatic versioning and tagging process.